### PR TITLE
Issue #13: Bump required "catalog" version to 0.6.0-alpha

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "~5.6.0|~7.0",
         "ext-memcached": ">=1.0 <2.2 || >=3.0.0",
-        "lizards-and-pumpkins/catalog": "^0.5.0-alpha"
+        "lizards-and-pumpkins/catalog": "^0.6.0-alpha"
     },
     "require-dev": {
         "phpunit/phpunit": "5.3.*",


### PR DESCRIPTION
Closes #13.